### PR TITLE
Subscriptions

### DIFF
--- a/routes/test.js
+++ b/routes/test.js
@@ -10,7 +10,39 @@ router.get('/', function(req, res, next) {
 
     if (req.session.user) {
         db.readOnlyConnection.query(`SELECT id, title FROM productions;`, function(err, rows, fields) {
-            sub.activateSubscription(req);
+            console.log(`Subscription should be null: ${req.session.subscriptionActiveUntil}`);
+            console.log(`Subscription ${sub.subscriptionActive(req) ? "is" : "is not"} active.\n`);
+            sub.activateSubscription(req, 1);
+            console.log(`Subscription should be a month from now: ${req.session.subscriptionActiveUntil}`);
+            console.log(`Subscription ${sub.subscriptionActive(req) ? "is" : "is not"} active.\n`);
+
+            sub.renewSubscription(req);
+            console.log(`Subscription should be two months from now: ${req.session.subscriptionActiveUntil}`);
+            console.log(`Subscription ${sub.subscriptionActive(req) ? "is" : "is not"} active.\n`);
+
+            // sub.cancelSubscription(req);
+            // console.log(`Subscription should be null: ${req.session.subscriptionActiveUntil}`);
+            // console.log(`Subscription ${sub.subscriptionActive(req) ? "is" : "is not"} active.\n`);
+
+            var myProd = "theOffice";
+            var myProd2 = "mrRobot";
+
+            console.log(`User ${sub.hasAccessTo(req, myProd) ? "has" : "has no"} access to ${myProd}.`);
+            console.log(`Requesting access to ${myProd} and ${myProd2}.`);
+            console.log(`User is ${sub.requestAccessTo(req, myProd) ? "granted" : "not granted"} access to ${myProd}.`);
+            console.log(`User is ${sub.requestAccessTo(req, myProd2) ? "granted" : "not granted"} access to ${myProd2}.`);
+            console.log(`User ${sub.hasAccessTo(req, myProd) ? "has" : "has no"} access to ${myProd}.`);
+            console.log(`User ${sub.hasAccessTo(req, myProd2) ? "has" : "has no"} access to ${myProd2}.\n`);
+
+            console.log(`Removing access to ${myProd}.`);
+            sub.removeAccessTo(req, myProd);
+            console.log(`User ${sub.hasAccessTo(req, myProd) ? "has" : "has no"} access to ${myProd}.\n`);
+            console.log(`Requesting access to ${myProd2} again.`);
+            console.log(`User is ${sub.requestAccessTo(req, myProd2) ? "granted" : "not granted"} access to ${myProd2}.`);
+            console.log(`User ${sub.hasAccessTo(req, myProd) ? "has" : "has no"} access to ${myProd}.`);
+            console.log(`User ${sub.hasAccessTo(req, myProd2) ? "has" : "has no"} access to ${myProd2}.`);
+
+
             res.render('test', { title: 'Whitefox Streaming Video', message: `Welcome, ${req.session.user}!`, user: req.session.user, displayProductions: rows});
         });
 

--- a/routes/test.js
+++ b/routes/test.js
@@ -2,6 +2,7 @@ var express = require('express');
 var router = express.Router();
 
 var db = require("../db-helper");
+var sub = require("../subscription-helper");
 
 //page for testing raw functionality
 
@@ -9,7 +10,7 @@ router.get('/', function(req, res, next) {
 
     if (req.session.user) {
         db.readOnlyConnection.query(`SELECT id, title FROM productions;`, function(err, rows, fields) {
-            console.log(rows);
+            sub.activateSubscription(req);
             res.render('test', { title: 'Whitefox Streaming Video', message: `Welcome, ${req.session.user}!`, user: req.session.user, displayProductions: rows});
         });
 

--- a/subscription-helper.js
+++ b/subscription-helper.js
@@ -1,5 +1,83 @@
 var db = require('./db-helper.js');
 
+var activateSubscription = function (req, slots) {
+    var expiryDate = new Date();
+    expiryDate.setDate(expiryDate.getDate() + 30);
+    req.session.subscriptionActiveUntil = expiryDate;
+    req.session.slotsAllowed = slots;
+    req.session.activeSlots = 0;
+    req.session.slots = [];
+
+};
+
+var renewSubscription = function (req) {
+    req.session.activeSubscriptionUntil.setDate(req.session.activeSubscriptionUntil.getDate() + 30);
+};
+
+var cancelSubscription = function (req) {
+    req.session.subscriptionActiveUntil = null;
+    req.session.slotsAllowed = 0;
+    req.session.activeSlots = 0;
+};
+
+var subscriptionActive = function (req) {
+    var now = new Date();
+    return (req.session.subscriptionActiveUntil > now);
+};
 
 
-exports = module.exports = {};
+
+var hasAccessTo = function (req, production) {
+    if (subscriptionActive(req)) {
+        req.session.slots.forEach(function (slot) {
+            if (slot.productionID === production) {
+                return true;
+            }
+        });
+    }
+    //else
+    return false;
+};
+
+var grantAccessTo = function (req, production) {
+    if (req.session.activeSlots < req.session.slotsAllowed) {
+        var expiryDate = new Date();
+        expiryDate.setDate(expiryDate.getDate() + 30);
+        req.session.slots.push({"productionID": production, "expiryDate": expiryDate});
+        return true;
+    }
+    else {
+        return false;
+    }
+};
+
+var requestAccessTo = function (req, production) {
+    if (hasAccessTo(req, production)) {
+        return true;
+    }
+    else {
+        return grantAccessTo(req, production);
+    }
+};
+
+var removeAccessTo = function (req, production) {
+    for (var i = 0; i < req.session.slots.length; i++) {
+        if (req.session.slots[i].productionID === production) {
+            req.session.slots.splice(i, 1);
+        }
+    }
+};
+
+var refreshAccessLists = function (req) {
+    var now = new Date();
+    req.session.slots.forEach(function (slot) {
+        if (slot.expiryDate < now) {
+            removeAccessTo(req, slot.productionID);
+        }
+    });
+};
+
+
+
+
+exports = module.exports = {activateSubscription, renewSubscription, cancelSubscription, hasAccessTo, grantAccessTo, requestAccessTo, removeAccessTo, refreshAccessLists};

--- a/subscription-helper.js
+++ b/subscription-helper.js
@@ -1,5 +1,21 @@
 var db = require('./db-helper.js');
 
+var syncSessionWithDb = function (req, callback) {
+    db.readOnlyConnection.query(`SELECT * FROM subscriptions WHERE subscriber = "${req.session.user}";`, function(err, rows, fields) {
+        req.session.subscriptionActiveUntil = rows[0].subscriptionExpiry;
+        req.session.slotsAllowed = rows[0].slotCount;
+    });
+
+    db.readOnlyConnection.query(`SELECT * FROM slots WHERE subscriber = "${req.session.user}";`, function(err, rows, fields) {
+        req.session.slots = [];
+        req.session.activeSlots = rows.length;
+        rows.forEach(function (slot) {
+            req.session.slots.push({"productionID": slot.production, "expiryDate": slot.expiry})
+
+        });
+    });
+};
+
 var activateSubscription = function (req, slots) {
     var expiryDate = new Date();
     expiryDate.setDate(expiryDate.getDate() + 30);
@@ -11,7 +27,7 @@ var activateSubscription = function (req, slots) {
 };
 
 var renewSubscription = function (req) {
-    req.session.activeSubscriptionUntil.setDate(req.session.activeSubscriptionUntil.getDate() + 30);
+    req.session.subscriptionActiveUntil.setDate(req.session.subscriptionActiveUntil.getDate() + 30);
 };
 
 var cancelSubscription = function (req) {
@@ -25,18 +41,17 @@ var subscriptionActive = function (req) {
     return (req.session.subscriptionActiveUntil > now);
 };
 
-
-
 var hasAccessTo = function (req, production) {
+    var accessible = false;
     if (subscriptionActive(req)) {
         req.session.slots.forEach(function (slot) {
             if (slot.productionID === production) {
-                return true;
+                accessible = true;
             }
         });
     }
-    //else
-    return false;
+
+    return accessible;
 };
 
 var grantAccessTo = function (req, production) {
@@ -44,6 +59,7 @@ var grantAccessTo = function (req, production) {
         var expiryDate = new Date();
         expiryDate.setDate(expiryDate.getDate() + 30);
         req.session.slots.push({"productionID": production, "expiryDate": expiryDate});
+        req.session.activeSlots += 1;
         return true;
     }
     else {
@@ -64,10 +80,12 @@ var removeAccessTo = function (req, production) {
     for (var i = 0; i < req.session.slots.length; i++) {
         if (req.session.slots[i].productionID === production) {
             req.session.slots.splice(i, 1);
+            req.session.activeSlots -= 1;
         }
     }
 };
 
+//not yet tested
 var refreshAccessLists = function (req) {
     var now = new Date();
     req.session.slots.forEach(function (slot) {
@@ -80,4 +98,4 @@ var refreshAccessLists = function (req) {
 
 
 
-exports = module.exports = {activateSubscription, renewSubscription, cancelSubscription, hasAccessTo, grantAccessTo, requestAccessTo, removeAccessTo, refreshAccessLists};
+exports = module.exports = {activateSubscription, renewSubscription, cancelSubscription, subscriptionActive, hasAccessTo, grantAccessTo, requestAccessTo, removeAccessTo, refreshAccessLists};


### PR DESCRIPTION
Subscription functionality written and tested **against session store only**.  This means that once a user logs out, all subscription info is lost.  Next up is the user-based persistent db account information.

The reason the information is duplicated across user-related tables and the session store is so because it's much easier for us (devs) to interact with the session store than to query the db directly every time we want to query/write something.

I may clean up that interaction at a later date to eliminate that duplication.